### PR TITLE
Use tighter letter spacing for main title

### DIFF
--- a/components/Main.module.scss
+++ b/components/Main.module.scss
@@ -16,6 +16,7 @@
 .title {
   font-size: 2.25rem;
   font-weight: 200;
+  letter-spacing: -0.03em;
   line-height: 2.5rem;
 
   @media (min-width: 768px) {


### PR DESCRIPTION
For easier readability of the large text.

Before:
![Screen Shot 2021-06-29 at 12 22 24](https://user-images.githubusercontent.com/8205055/123751962-f2519a80-d8d5-11eb-9173-9d01ea4656be.png)

After:
![Screen Shot 2021-06-29 at 12 22 42](https://user-images.githubusercontent.com/8205055/123751984-fa113f00-d8d5-11eb-8237-1fe883c141b9.png)
