### PR TITLE
Specify viewport meta tag

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,18 @@
 import { ReactElement } from 'react'
 import { AppProps } from 'next/app'
+import Head from 'next/head'
 
 import '../styles/globals.scss'
 
 type IMyApp = { (props: AppProps): ReactElement }
 
-const MyApp: IMyApp = ({ Component, pageProps }) => <Component {...pageProps} />
+const MyApp: IMyApp = ({ Component, pageProps }) => (
+  <>
+    <Head>
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+    </Head>
+    <Component {...pageProps} />
+  </>
+)
 
 export default MyApp


### PR DESCRIPTION
With `initial-scale=1`, so that pages scale correctly on small screens.

Next.js does add a `<meta name="viewport" content="width=device-width" />` to all pages, but it does not specify `initial-scale=1`. As a result, this happens on small screens:

![Screenshot 2021-06-29 at 12-34-11 Vala Programming Language](https://user-images.githubusercontent.com/8205055/123755528-9c7ef180-d8d9-11eb-9ff4-ee95f977478d.png)

