### PR TITLE
change telegram link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -86,7 +86,7 @@ mastodon = "https://mastodon.social/@vala_lang"
 
 discord = "https://discord.gg/YFAzjSVHt7"
 
-telegram = "https://t.me/codefaq"
+telegram = "https://t.me/vala_lang"
 
 twitter = "https://www.twitter.com/vala_lang"
 


### PR DESCRIPTION
A more appropriate link was chosen for the telegram group.