### PR TITLE
Don't duplicate "View The Website's Source Code" in footer

### DIFF
--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -10,7 +10,7 @@
     </ul>
     <div>{{ trans(key='made_by_vala_community', lang=lang) }}</div>
     <a href="{{ config.extra.site_source_code_url }}">{{ trans(key='view_website_source_code', lang=lang) }}</a>
-    <p>{{ trans(key='view_website_source_code', lang=lang) }} <a rel="license" href="{{ config.extra.license_url }}">Creative Commons Attribution-ShareAlike 4.0 International License.</a></p>
+    <p>{{ trans(key='license_description', lang=lang) }} <a rel="license" href="{{ config.extra.license_url }}">Creative Commons Attribution-ShareAlike 4.0 International License.</a></p>
   </div>
 </footer>
 


### PR DESCRIPTION
:thinking: Likely introduced in [this commit](https://github.com/vala-lang/vala-www/commit/cdb6e654cd962da9d0eb15884b48c3ce679a262d#diff-f10f1eb248ae6ce257fc065abb760dcf98ece6a93a5f9de5bc80dbd08db98f99):

https://github.com/vala-lang/vala-www/blob/6b2e6435d70ca38295c2fde5c4d6592d806b0fd8/templates/partials/footer.html#L12-L13

I updated the latter `view_website_source_code` to `license_description`:

https://github.com/vala-lang/vala-www/blob/6b2e6435d70ca38295c2fde5c4d6592d806b0fd8/config.toml#L112