### PR TITLE
docs(fr): translate remaining locale strings

### DIFF
--- a/.vitepress/locales/fr.js
+++ b/.vitepress/locales/fr.js
@@ -86,15 +86,15 @@ export default {
 
   page_not_found: 'Erreur 404 - Page non trouvé',
   page_not_found_description: "la page que vous avez demandée n'existe plus.",
-  go_home: 'Go Home',
+  go_home: 'Accueil',
 
-  current_versions: 'Current Versions',
-  install_how: 'How to install',
+  current_versions: 'Versions actuelles',
+  install_how: 'Comment installer',
   stable: 'Stable',
-  stable_lts: 'Stable Long-term Support',
-  devel: 'Development',
+  stable_lts: 'Support à long terme',
+  devel: 'Développement',
 
-  roadmap: 'Roadmap',
+  roadmap: 'Feuille de route',
 
   site_title: 'Langage de programmation Vala',
   site_description:


### PR DESCRIPTION
Fixes #245

## Changes
- Translate the seven French locale values listed in issue #245.
- Keep the existing locale keys and formatting intact.

## Verification
- `bun run build` passed.
- `node --check .vitepress/locales/fr.js` passed.
- `git diff --check` passed.
- `bunx prettier --check .vitepress/locales/fr.js` reports pre-existing formatting differences in this file; this PR does not reformat unrelated lines.

## AI disclosure
This PR was prepared with AI assistance. I reviewed the change against the English locale and the issue's exact key list.