### PR TITLE
Translate remaining untranslated strings in French locale

### DIFF
--- a/.vitepress/locales/fr.js
+++ b/.vitepress/locales/fr.js
@@ -86,15 +86,15 @@ export default {
 
   page_not_found: 'Erreur 404 - Page non trouvé',
   page_not_found_description: "la page que vous avez demandée n'existe plus.",
-  go_home: 'Go Home',
+ go_home: "Retour à l'accueil",
 
-  current_versions: 'Current Versions',
-  install_how: 'How to install',
-  stable: 'Stable',
-  stable_lts: 'Stable Long-term Support',
-  devel: 'Development',
+current_versions: "Versions actuelles",
+install_how: "Comment installer",
+stable: "Stable",
+stable_lts: "Stable à long terme",
+devel: "Développement",
 
-  roadmap: 'Roadmap',
+roadmap: "Feuille de route",
 
   site_title: 'Langage de programmation Vala',
   site_description:

--- a/.vitepress/locales/fr.js
+++ b/.vitepress/locales/fr.js
@@ -86,15 +86,16 @@ export default {
 
   page_not_found: 'Erreur 404 - Page non trouvé',
   page_not_found_description: "la page que vous avez demandée n'existe plus.",
- go_home: "Retour à l'accueil",
 
-current_versions: "Versions actuelles",
-install_how: "Comment installer",
-stable: "Stable",
-stable_lts: "Stable à long terme",
-devel: "Développement",
+  go_home: "Retour à l'accueil",
 
-roadmap: "Feuille de route",
+  current_versions: "Versions actuelles",
+  install_how: "Comment installer",
+  stable: "Stable",
+  stable_lts: "Stable à long terme",
+  devel: "Développement",
+
+  roadmap: "Feuille de route",
 
   site_title: 'Langage de programmation Vala',
   site_description:


### PR DESCRIPTION
## Summary

This PR translates the remaining untranslated strings in the French locale file (`.vitepress/locales/fr.js`).

### Changes
- Translated `go_home`
- Translated `current_versions`
- Translated `install_how`
- Translated `stable_lts`
- Translated `devel`
- Translated `roadmap`

(`stable` remains unchanged because the French term is also "Stable".)

Part of #245